### PR TITLE
Add render Mission UI as well as join and leave mission method

### DIFF
--- a/src/components/Mission.component.jsx
+++ b/src/components/Mission.component.jsx
@@ -1,29 +1,89 @@
 import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { joinMission, leaveMission } from 'redux/missions/missions';
 import './styles.components/Mission.style.scss';
 
 function Mission({ mission }) {
-  const { description, mission_name: missionName } = mission;
+  const {
+    description,
+    missionName,
+    reserved,
+    missionId,
+  } = mission;
+
+  const dispatch = useDispatch();
+
+  const joinHandler = (e) => {
+    const { id } = e.target;
+    dispatch(joinMission(id));
+  };
+
+  const leaveHandler = (e) => {
+    const { id } = e.target;
+    dispatch(leaveMission(id));
+  };
   return (
-    <div className="mission">
-      <p>{missionName}</p>
-      <span>{description}</span>
-      <button type="button">Click</button>
+    <div className="mission table-template">
+      <h3 className="t-cell">{missionName}</h3>
+      <span className="t-cell">{description}</span>
+      <span className="t-cell center">
+        <button
+          id={missionId}
+          type="button"
+          onClick={joinHandler}
+          style={
+            reserved ? {
+              backgroundColor: 'lightBlue',
+              color: '#000',
+              fontSize: '10px',
+            } : {
+              backgroundColor: 'gray',
+              color: 'white',
+              fontSize: '10px',
+            }
+          }
+        >
+          {reserved ? 'Active Member' : 'NOT A MEMBER'}
+        </button>
+      </span>
+      <span className="t-cell center">
+        <button
+          type="button"
+          onClick={leaveHandler}
+          id={missionId}
+          style={
+            reserved ? {
+              color: 'red',
+              border: '1px solid red',
+            } : {
+              color: '#000',
+              border: '1px solid #000',
+            }
+          }
+        >
+          {reserved ? 'Leave Mission' : 'Join Mission'}
+        </button>
+      </span>
     </div>
   );
 }
 
 Mission.defaultProps = {
   mission: {
-    mission_name: '',
+    missionName: '',
     description: '',
+    reserved: false,
+    missionId: '',
   },
 };
 
 Mission.propTypes = {
   mission: PropTypes.shape(
     {
-      mission_name: PropTypes.string,
+      missionName: PropTypes.string,
       description: PropTypes.string,
+      reserved: PropTypes.bool,
+      missionId: PropTypes.string,
       // flickr_images: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string])),
     },
   ),

--- a/src/components/styles.components/Mission.style.scss
+++ b/src/components/styles.components/Mission.style.scss
@@ -1,3 +1,37 @@
+$table-border: 1px solid #000;
+
 .mission {
   margin: 0;
+  font-size: 12px;
+
+  .t-cell {
+    margin: 0;
+    padding: 10px;
+    border: $table-border;
+    border-top: none;
+  }
+
+  button {
+   padding: 10px;
+   border-radius: 5px; 
+   border: none;
+   font-weight: 300;
+   cursor: pointer;
+   box-shadow: rgba(0, 0, 0, 0.24) 0 3px 8px;
+   transition: 0.5s;
+  }
+
+  button:hover {
+    transform: scale(1.1, 1.1);
+  }
+
+  .center {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+.mission:nth-child(2n) {
+  background-color: #6a686836;
 }

--- a/src/components/styles.components/Mission.style.scss
+++ b/src/components/styles.components/Mission.style.scss
@@ -12,13 +12,13 @@ $table-border: 1px solid #000;
   }
 
   button {
-   padding: 10px;
-   border-radius: 5px; 
-   border: none;
-   font-weight: 300;
-   cursor: pointer;
-   box-shadow: rgba(0, 0, 0, 0.24) 0 3px 8px;
-   transition: 0.5s;
+    padding: 10px;
+    border-radius: 5px;
+    border: none;
+    font-weight: 300;
+    cursor: pointer;
+    box-shadow: rgba(0, 0, 0, 0.24) 0 3px 8px;
+    transition: 0.5s;
   }
 
   button:hover {

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -24,17 +24,44 @@ const missionsSlice = createSlice({
   name: 'missions',
   initialState,
   reducers: {
-
+    joinMission: (state, action) => {
+      const { payload } = action;
+      const missions = state.missions.map((mission) => {
+        if (mission.missionId !== payload) {
+          return mission;
+        }
+        return { ...mission, reserved: true };
+      });
+      return { missions, status: state.status };
+    },
+    leaveMission: (state, action) => {
+      const { payload } = action;
+      const missions = state.missions.map((mission) => {
+        if (mission.missionId !== payload) {
+          return mission;
+        }
+        return { ...mission, reserved: false };
+      });
+      return { missions, status: state.status };
+    },
   },
   extraReducers(builder) {
     builder.addCase(getMissions.fulfilled, (status, action) => {
       const { payload } = action;
+      const missions = payload.map((mission) => ({
+        description: mission.description,
+        missionName: mission.mission_name,
+        missionId: mission.mission_id,
+        reserved: false,
+      }));
       return {
-        missions: payload,
+        missions,
         status: 'completed',
       };
     });
   },
 });
+
+export const { joinMission, leaveMission } = missionsSlice.actions;
 
 export default missionsSlice.reducer;

--- a/src/routes/missions.route.jsx
+++ b/src/routes/missions.route.jsx
@@ -2,11 +2,12 @@ import Mission from 'components/Mission.component';
 import { useSelector, useDispatch } from 'react-redux';
 import { useEffect } from 'react';
 import { getMissions } from 'redux/missions/missions';
+import './styles.routes/missions.styles.scss';
 
 function Missions() {
   const dispatch = useDispatch();
   const { missions, status } = useSelector((state) => state.missions);
-
+  console.log(missions);
   useEffect(() => {
     if (status === 'update') {
       // eslint-disable-next-line
@@ -16,9 +17,15 @@ function Missions() {
 
   return (
     <div className="missions-container">
+      <div className="header table-template">
+        <span>Mission</span>
+        <span>Description</span>
+        <span>Status</span>
+        <span />
+      </div>
       {
         missions.map((mission) => (
-          <Mission key={mission.mission_id} mission={mission} />
+          <Mission key={mission.missionId} mission={mission} />
         ))
       }
     </div>

--- a/src/routes/styles.routes/missions.styles.scss
+++ b/src/routes/styles.routes/missions.styles.scss
@@ -1,3 +1,20 @@
-.missions {
-  margin: 0;
+$table-border: 1px solid #000;
+
+.missions-container {
+  margin: 2rem 5rem;
+
+  .table-template {
+    display: grid;
+    grid-template-columns: 8rem 1fr 8rem 8rem;
+    border: $table-border;
+  }
+
+  .header {
+    span {
+      border: $table-border;
+      padding: 5px;
+      font-weight: bold;
+      font-size: 18px;
+    }
+  }
 }


### PR DESCRIPTION
- [ ]  Render Mission UI
The Missions section displays a list of current missions along with their brief description and participation status. There is also a button next to each mission that allows users to join the selected mission or leave the mission the user joined earlier.
![image](https://user-images.githubusercontent.com/113169577/223678137-43880683-5246-4f6b-86cd-ae968fbce6be.png)

- [ ] implement join and leave mission method
- Create a reducer and action dispatcher for the "Join Mission" button. When a user clicks the "Reserve rocket" button -  action needs to be dispatched to update the store. You need to get the ID of the reserved rocket and update the state. Remember you mustn't mutate the state. Instead, you need to return a new state object with all rockets, but the selected rocket will have an extra key reserved with its value set to true. You could use a JS` filter()` or `map()` to set the value of the new state. you need to pass the mission's ID to the corresponding action and update the missions' state with the selected mission having a new key/value - `reserved: true`.
- Write actions and reducers for leaving missions: Here you need to follow the same logic as with the "Reserve rocket"/"Reserve dragon" and "Join mission" - but you need to set the reserved key to false. Dispatch these actions upon click on the corresponding buttons.

- [ ] style for Mission UI